### PR TITLE
Simplify code and support urlencoded string

### DIFF
--- a/easytpl.go
+++ b/easytpl.go
@@ -221,11 +221,11 @@ func prepareTemplateTags(body string) (string, map[string][]string) {
 			return match
 		}
 
-		if len(tagParts) > 0 {
+		if len(tagParts[0]) > 0 {
 			tagParts[0] = strings.ToUpper(tagParts[0][0:1]) + tagParts[0][1:]
 		}
 
-		if len(tagParts) > 1 {
+		if len(tagParts[1]) > 0 {
 			tagParts[1] = strings.ToUpper(tagParts[1][0:1]) + tagParts[1][1:]
 		}
 

--- a/easytpl_test.go
+++ b/easytpl_test.go
@@ -181,6 +181,14 @@ func TestHTMLSafe(t *testing.T) {
 		expectedErr error
 	}{
 		{
+			`<a href="http://example.com/{%Test.Test,fallback=foo%}?a={%Test.Test,fallback=bar%}">
+			{%Test.Test,fallback=world%}</a>`,
+			map[string]Templateable{},
+			`<a href="http://example.com/foo?a=bar">
+			world</a>`,
+			nil,
+		},
+		{
 			`<a href="http://example.com/{%Test.Test%}?a={%Test.Test%}">{%Test.Test%}</a>`,
 			map[string]Templateable{
 				"Test": TestKeys{keys: Keys{
@@ -291,6 +299,10 @@ func TestPrepareTemplateTags(t *testing.T) {
 		{
 			`this is a test {{ "{{ foo }}" }} bar {% template.tag %} {{hello}}`,
 			`this is a test {{ "{{ foo }}" }} bar {{.Template.Tag}} {{ "{{hello}}" }}`,
+		},
+		{
+			`this is a test <a href="http://teamwork.com/?param=%7B%25ticket.id%25%7D">{%ticket.id%}</a>`,
+			`this is a test <a href="http://teamwork.com/?param={{.Ticket.Id}}">{{.Ticket.Id}}</a>`,
 		},
 		// This is how Squire sends multiple spaces.
 		// TODO: Fix this!

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/teamwork/test v0.0.0-20180314232558-4dd91ae70361 h1:EgiydeUm3lPAvut4wzY7+TBkO6DUnBp4xqKvhtfE70Y=
 github.com/teamwork/test v0.0.0-20180314232558-4dd91ae70361/go.mod h1:TIbx7tx6WHBjQeLRM4eWQZBL7kmBZ7/KI4x4v7Y5YmA=
 github.com/teamwork/utils v0.0.0-20180315024146-080b8a81043e h1:Cwj9O70KwYUCnhUh/cQoGXh4+cym7xlurdziq47BtVo=
 github.com/teamwork/utils v0.0.0-20180315024146-080b8a81043e/go.mod h1:rmPaJUVv426LGg3QR31m1N0bfpCdCVyh3dCWsJTQeDA=


### PR DESCRIPTION
The problem arose where we have people adding variables into a URL. The problem is that generally these are URL encoded before being sent to the server, which is correct, really. The problem is that our current regular expression won't detect this. When trying to update this I found the code quite difficult to follow and set about cleaning it up.

I find this change to be much cleaner and easier to follow/read. There may be a slight performance cost but it should be negligable and unimportant in this case for realistic usage. The regex should also be easier to follow and less error prone as the negative lookup was not necessary. The controversial part of this PR may be that it now includes the URLEncoded version of the identifier in the expression. There are other ways to solve this but I decided on this one. The cleanup could be viewed separate to this if we didn't want to go ahead with this solution for the URL encoding.